### PR TITLE
feat json parse

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { LoadingOutlined } from '@ant-design/icons';
-import { App as AppWrapper, Empty, Layout, Spin, theme } from 'antd';
+import { App as AppWrapper, Empty, Layout, message, Spin, theme } from 'antd';
 import { MappingAlgorithm } from 'antd/es/config-provider/context';
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useRoutes } from 'react-router-dom';
 
 import { useAuthentication } from './hooks';
@@ -21,8 +21,12 @@ function App() {
   useAuthentication();
 
   const routesContent = useRoutes(routerConfig);
-
+  const [messageApi, contextHolder] = message.useMessage();
   const { theme, darkMode, compactMode, colorPrimary, language } = useUserProfile();
+
+  useEffect(() => {
+    window.message = messageApi;
+  }, []);
 
   const algorithm = useMemo<MappingAlgorithm[]>(() => {
     const _algorithm = [defaultAlgorithm];
@@ -42,6 +46,7 @@ function App() {
     >
       <GlobalStyle>
         <AppWrapper>
+          {contextHolder}
           <Layout>
             <Content>{routesContent}</Content>
           </Layout>

--- a/src/components/StructuredFilter/index.tsx
+++ b/src/components/StructuredFilter/index.tsx
@@ -23,7 +23,6 @@ export type StructuredFilterProps = {
   size?: SizeType;
   prefix?: ReactNode;
   showSearchButton?: boolean | 'simple';
-  keywordPlaceholder?: string;
   onSearch?: (value: SearchDataType) => void;
   onChange?: (value: SearchDataType) => void;
   options: StructuredOptionType[];
@@ -57,7 +56,7 @@ const StructuredFilterWrapper = styled.div<{ size: SizeType }>`
 `;
 
 const StructuredFilter: FC<StructuredFilterProps> = (props) => {
-  const { showSearchButton = true, size, options, keywordPlaceholder, ...restProps } = props;
+  const { showSearchButton = true, size, options, ...restProps } = props;
   const { t } = useTranslation(['common']);
 
   const selectRef = useRef<BaseSelectRef>(null);
@@ -160,7 +159,6 @@ const StructuredFilter: FC<StructuredFilterProps> = (props) => {
                 ref={structuredOptionRef}
                 size={size}
                 keyword={keyword}
-                keywordPlaceholder={keywordPlaceholder}
                 options={options}
                 onChange={handleChange}
                 onSearch={handleSearch}

--- a/src/components/appSetting/NodesIgnore/index.tsx
+++ b/src/components/appSetting/NodesIgnore/index.tsx
@@ -1,10 +1,15 @@
 import { useRequest } from 'ahooks';
 import { App, Col, Divider, Row } from 'antd';
 import { DataNode, TreeProps } from 'antd/lib/tree';
+import { stringify } from 'lossless-json';
 import React, { FC, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { tryParseJsonString, tryPrettierJsonString } from '../../../helpers/utils';
+import {
+  tryParseJsonString,
+  tryPrettierJsonString,
+  tryStringifyJson,
+} from '../../../helpers/utils';
 import AppSettingService from '../../../services/AppSetting.service';
 import { QueryIgnoreNode, QueryInterfaceIgnoreNode } from '../../../services/AppSetting.type';
 import { FileSystemService } from '../../../services/FileSystem.service';
@@ -217,7 +222,7 @@ const SettingNodesIgnore: FC<SettingNodeIgnoreProps> = (props) => {
     if (!!activeOperationInterface?.id && parsed) {
       updateInterfaceResponse({
         id: activeOperationInterface.id,
-        operationResponse: JSON.stringify(parsed),
+        operationResponse: tryStringifyJson(parsed),
       });
       handleCancelEditResponse(true);
     }

--- a/src/components/http/components/http/RawBody.tsx
+++ b/src/components/http/components/http/RawBody.tsx
@@ -1,9 +1,10 @@
 import { json } from '@codemirror/lang-json';
 import { css } from '@emotion/react';
-import { App } from 'antd';
+import { message } from 'antd';
 import React, { forwardRef, useContext, useImperativeHandle, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { tryPrettierJsonString } from '../../../../helpers/utils';
 import { useCodeMirror } from '../../helpers/editor/codemirror';
 import { HttpContext } from '../../index';
 
@@ -12,8 +13,6 @@ export type HttpRawBodyRef = {
 };
 
 const HttpRawBody = forwardRef<HttpRawBodyRef>((props, ref) => {
-  const { message } = App.useApp();
-
   const rawBodyParameters = useRef<HTMLDivElement>(null);
   const { store, dispatch } = useContext(HttpContext);
   const { t } = useTranslation();
@@ -34,14 +33,12 @@ const HttpRawBody = forwardRef<HttpRawBodyRef>((props, ref) => {
   });
 
   const prettifyRequestBody = () => {
-    try {
-      const jsonObj = JSON.parse(store.request.body.body as string);
-      dispatch((state) => {
-        state.request.body.body = JSON.stringify(jsonObj, null, 2);
-      });
-    } catch (e) {
-      message.error(t('error.json_prettify_invalid_body'));
-    }
+    dispatch((state) => {
+      state.request.body.body = tryPrettierJsonString(
+        store.request.body.body,
+        t('error.json_prettify_invalid_body'),
+      ) as string;
+    });
   };
 
   return (

--- a/src/components/http/extra/tabs/request/Mock.tsx
+++ b/src/components/http/extra/tabs/request/Mock.tsx
@@ -2,12 +2,11 @@ import { SaveOutlined } from '@ant-design/icons';
 import { json } from '@codemirror/lang-json';
 import { useRequest } from 'ahooks';
 import { App, Col, Collapse, Row, Space } from 'antd';
-import { stringify } from 'lossless-json';
 import React, { FC } from 'react';
 import { useImmer } from 'use-immer';
 
 import request from '../../../../../helpers/api/request';
-import { tryParseJsonString } from '../../../../../helpers/utils';
+import { tryParseJsonString, tryStringifyJson } from '../../../../../helpers/utils';
 import useUserProfile from '../../../../../store/useUserProfile';
 import { EmptyWrapper, WatermarkCodeMirror } from '../../../../styledComponents';
 import TooltipButton from '../../../../TooltipButton';
@@ -69,7 +68,7 @@ const Mock: FC<{ recordId: string }> = ({ recordId }) => {
 
               const convertData = (data: MockTarget) => {
                 const { body, bodyParsed, ...rest } = data;
-                return stringify({ body: bodyParsed || body, ...rest }, undefined, 2);
+                return tryStringifyJson({ body: bodyParsed || body, ...rest }, undefined, true);
               };
 
               return {
@@ -117,10 +116,10 @@ const Mock: FC<{ recordId: string }> = ({ recordId }) => {
     params.targetResponse = tryParseJsonString(targetResponseString);
 
     typeof params.targetRequest.body !== 'string' &&
-      (params.targetRequest.body = stringify(params.targetRequest.body));
+      (params.targetRequest.body = tryStringifyJson(params.targetRequest.body));
 
     typeof params.targetResponse.body !== 'string' &&
-      (params.targetResponse.body = stringify(params.targetResponse.body));
+      (params.targetResponse.body = tryStringifyJson(params.targetResponse.body));
 
     updateMockData(params);
   };

--- a/src/components/http/extra/tabs/request/Mock.tsx
+++ b/src/components/http/extra/tabs/request/Mock.tsx
@@ -1,24 +1,25 @@
 import { SaveOutlined } from '@ant-design/icons';
 import { json } from '@codemirror/lang-json';
 import { useRequest } from 'ahooks';
-import { Alert, App, Card, Col, Collapse, Row, Space } from 'antd';
+import { App, Col, Collapse, Row, Space } from 'antd';
+import { stringify } from 'lossless-json';
 import React, { FC } from 'react';
-import { useTranslation } from 'react-i18next';
 import { useImmer } from 'use-immer';
 
 import request from '../../../../../helpers/api/request';
-import { tryParseJsonString, tryPrettierJsonString } from '../../../../../helpers/utils';
+import { tryParseJsonString } from '../../../../../helpers/utils';
 import useUserProfile from '../../../../../store/useUserProfile';
 import { EmptyWrapper, WatermarkCodeMirror } from '../../../../styledComponents';
 import TooltipButton from '../../../../TooltipButton';
 
 type MockTarget = {
   body: string | null;
+  bodyParsed?: Record<string, any> | null;
   attributes: Record<string, any> | null;
   type: string | null;
 };
 
-type MockTargetParsed = { body: Record<string, any> | string | null } & Omit<MockTarget, 'body'>;
+type MockTargetParsed = { body?: string | null } & Omit<MockTarget, 'body'>;
 
 type MockData = {
   id: string;
@@ -48,7 +49,6 @@ const Mock: FC<{ recordId: string }> = ({ recordId }) => {
   const { message } = App.useApp();
   const { theme } = useUserProfile();
   const [mockData, setMockData] = useImmer<MockDataParse[]>([]);
-  const { t } = useTranslation(['components', 'common']);
 
   const { run: getMockData, loading } = useRequest<MockDataParse[], []>(
     () =>
@@ -60,23 +60,22 @@ const Mock: FC<{ recordId: string }> = ({ recordId }) => {
         .then((res) =>
           Promise.resolve(
             res.recordResult.map((result) => {
-              try {
-                result.targetRequest.body &&
-                  (result.targetRequest.body = JSON.parse(result.targetRequest.body));
-              } catch (e) {
-                console.info(e);
-              }
-              try {
-                result.targetResponse.body &&
-                  (result.targetResponse.body = JSON.parse(result.targetResponse.body));
-              } catch (e) {
-                console.info(e);
-              }
+              result.targetRequest.bodyParsed = tryParseJsonString<Record<string, any>>(
+                result.targetRequest.body,
+              );
+              result.targetResponse.bodyParsed = tryParseJsonString<Record<string, any>>(
+                result.targetResponse.body,
+              );
+
+              const convertData = (data: MockTarget) => {
+                const { body, bodyParsed, ...rest } = data;
+                return stringify({ body: bodyParsed || body, ...rest }, undefined, 2);
+              };
 
               return {
                 ...result,
-                targetRequestString: tryPrettierJsonString(JSON.stringify(result.targetRequest)),
-                targetResponseString: tryPrettierJsonString(JSON.stringify(result.targetResponse)),
+                targetRequestString: convertData(result.targetRequest),
+                targetResponseString: convertData(result.targetResponse),
               };
             }),
           ),
@@ -114,13 +113,14 @@ const Mock: FC<{ recordId: string }> = ({ recordId }) => {
 
     const { targetRequestString, targetResponseString, ...params } = data;
 
-    params.targetRequest = tryParseJsonString(targetRequestString) as MockTarget;
-    params.targetResponse = tryParseJsonString(targetResponseString) as MockTarget;
+    params.targetRequest = tryParseJsonString(targetRequestString);
+    params.targetResponse = tryParseJsonString(targetResponseString);
 
     typeof params.targetRequest.body !== 'string' &&
-      (params.targetRequest.body = JSON.stringify(params.targetRequest.body));
+      (params.targetRequest.body = stringify(params.targetRequest.body));
+
     typeof params.targetResponse.body !== 'string' &&
-      (params.targetResponse.body = JSON.stringify(params.targetResponse.body));
+      (params.targetResponse.body = stringify(params.targetResponse.body));
 
     updateMockData(params);
   };
@@ -129,7 +129,6 @@ const Mock: FC<{ recordId: string }> = ({ recordId }) => {
     <Space direction='vertical' style={{ width: '100%' }}>
       <EmptyWrapper loading={loading} empty={!mockData.length}>
         <Space direction='vertical' style={{ width: '100%' }}>
-          {/*<Alert message={t('appSetting.mockTips')} type='info' showIcon />*/}
           <Collapse defaultActiveKey={mockData.map((mock) => mock.id)}>
             {mockData.map((mock) => (
               <Collapse.Panel
@@ -139,7 +138,10 @@ const Mock: FC<{ recordId: string }> = ({ recordId }) => {
                   <TooltipButton
                     title={'Save'}
                     icon={<SaveOutlined />}
-                    onClick={() => handleSave(mock.id)}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleSave(mock.id);
+                    }}
                   />
                 }
               >

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="vite/client" />
+import { MessageInstance } from 'antd/es/message/interface';
 import React, { FC, PropsWithChildren } from 'react';
 
 export type ReactFCWithChildren = React.FC<PropsWithChildren>;
@@ -8,6 +9,7 @@ export type FCC<P> = FC<PropsWithChildren<P>>;
 
 declare global {
   interface Window {
+    message: MessageInstance;
     __AREX_EXTENSION_INSTALLED__: boolean; // 是否安装了arex-chrome-extension
     __AREX_EXTENSION_VERSION__: string; // arex-chrome-extension 最新版本号
     __AREX_DESKTOP_AGENT__: boolean; //是否安装了arex桌面代理

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -1,4 +1,3 @@
-import { message } from 'antd';
 import { parse, stringify } from 'lossless-json';
 import { v4 as uuid } from 'uuid';
 
@@ -53,16 +52,28 @@ export function tryParseJsonString<T>(jsonString?: any, errorTip?: string) {
     return parse(jsonString || '{}') as T;
   } catch (e) {
     console.error(e);
-    errorTip && message.warning(errorTip);
+    errorTip && window.message.warning(errorTip);
     return jsonString;
   }
 }
+
+export const tryStringifyJson = (
+  jsonString?: object | null,
+  errorTip?: string,
+  prettier?: boolean,
+) => {
+  try {
+    return stringify(jsonString, undefined, prettier ? 2 : undefined);
+  } catch (e) {
+    errorTip && window.message.warning(errorTip);
+  }
+};
 
 export const tryPrettierJsonString = (jsonString: string, errorTip?: string) => {
   try {
     return stringify(parse(jsonString), undefined, 2);
   } catch (e) {
-    errorTip && message.warning(errorTip);
+    errorTip && window.message.warning(errorTip);
     return jsonString;
   }
 };

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -1,4 +1,5 @@
 import { message } from 'antd';
+import { parse, stringify } from 'lossless-json';
 import { v4 as uuid } from 'uuid';
 
 import { HoppRESTRequest } from '../components/http/data/rest';
@@ -32,7 +33,7 @@ export function setLocalStorage<T>(key: string, value?: T | ((state: T) => void)
     raw && (value as (state: T) => void)(raw);
     _value = raw;
   }
-  return window.localStorage.setItem(key, JSON.stringify(_value));
+  return window.localStorage.setItem(key, stringify(_value) || 'undefined');
 }
 
 /**
@@ -49,7 +50,7 @@ export function clearLocalStorage(key?: string) {
 
 export function tryParseJsonString<T>(jsonString?: any, errorTip?: string) {
   try {
-    return JSON.parse(jsonString || '{}') as T;
+    return parse(jsonString || '{}') as T;
   } catch (e) {
     console.error(e);
     errorTip && message.warning(errorTip);
@@ -59,7 +60,7 @@ export function tryParseJsonString<T>(jsonString?: any, errorTip?: string) {
 
 export const tryPrettierJsonString = (jsonString: string, errorTip?: string) => {
   try {
-    return JSON.stringify(JSON.parse(jsonString), null, 2);
+    return stringify(parse(jsonString), undefined, 2);
   } catch (e) {
     errorTip && message.warning(errorTip);
     return jsonString;
@@ -122,7 +123,7 @@ export function getChromeVersion() {
 
 export const JSONparse = (jsonString: string) => {
   try {
-    return JSON.parse(jsonString);
+    return parse(jsonString);
   } catch (e) {
     return undefined;
   }

--- a/src/services/AppSetting.type.ts
+++ b/src/services/AppSetting.type.ts
@@ -125,7 +125,7 @@ export type OperationId<T extends OperationType> = T extends 'Global'
 
 export interface UpdateInterfaceResponseReq {
   id: OperationId<'Interface'>;
-  operationResponse: string;
+  operationResponse?: string;
 }
 
 export interface IgnoreNodeBase {

--- a/src/store/useUserProfile.ts
+++ b/src/store/useUserProfile.ts
@@ -1,5 +1,5 @@
 import { mountStoreDevtool } from 'simple-zustand-devtools';
-import create from 'zustand';
+import { create } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
 
 import { UserProfileKey } from '../constant';


### PR DESCRIPTION
1. 提供三个 JSON 处理相关工具方法, 均使用 lossless-json 作为 Json 解析引擎, 且均做了错误拦截
 * tryParseJsonString
 * tryStringifyJson
 * tryPrettierJsonString
2. window 上新增挂载拥有上下文的 message api, 方便在 js 函数中直接调用