### PR TITLE
fix: report pagination reset

### DIFF
--- a/packages/arex/src/panes/Replay/PlanReport.tsx
+++ b/packages/arex/src/panes/Replay/PlanReport.tsx
@@ -6,7 +6,7 @@ import {
   useArexPaneProps,
   useTranslation,
 } from '@arextest/arex-core';
-import { usePagination } from 'ahooks';
+import { usePagination, useRequest } from 'ahooks';
 import { Card, theme, Tooltip, Typography } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
 import React, { FC, useEffect, useState } from 'react';
@@ -129,28 +129,35 @@ const PlanReport: FC<PlanReportProps> = (props) => {
 
   const [pollingInterval, setPollingInterval] = useState(true);
   const {
-    data: { list: planStatistics } = { list: [] },
-    pagination,
+    data: { list: planStatistics, pagination } = {
+      list: [],
+      pagination: {
+        current: defaultCurrent,
+        pageSize: defaultPageSize,
+        total: 0,
+      },
+    },
+    runAsync: queryPlanStatistics,
     loading,
     refresh,
     cancel: cancelPollingInterval,
-  } = usePagination(
+  } = useRequest(
     (params) =>
       ReportService.queryPlanStatistics({
         appId,
         planId: data?.planId || undefined,
+        current: defaultCurrent,
+        pageSize: defaultPageSize,
         ...params,
       }),
     {
       ready: !!appId,
       loadingDelay: 200,
       pollingInterval: 6000,
-      defaultPageSize,
-      defaultCurrent,
       refreshDeps: [appId, refreshDep, data?.planId],
       onSuccess({ list }) {
         if (init) {
-          list.length && onSelectedPlanChange(list[parseInt(searchParams.get('row') || '0')]);
+          list.length && handleRowClick?.(list[0], 1);
           setInit(false); // 设置第一次初始化标识);
         }
 
@@ -158,8 +165,6 @@ const PlanReport: FC<PlanReportProps> = (props) => {
           setPollingInterval(false);
           cancelPollingInterval();
         }
-
-        handleRowClick?.(list[0], 1);
       },
     },
   );
@@ -205,6 +210,14 @@ const PlanReport: FC<PlanReportProps> = (props) => {
           columns={columns}
           selectKey={selectKey}
           pagination={pagination}
+          onChange={(pagination) => {
+            if (Object.keys(pagination).length) {
+              queryPlanStatistics({
+                current: pagination.current,
+                pageSize: pagination.pageSize,
+              }).then(({ list }) => handleRowClick?.(list[0], 1));
+            }
+          }}
           onRowClick={handleRowClick}
           dataSource={planStatistics}
           sx={{

--- a/packages/arex/src/services/ReportService/queryPlanStatistics.ts
+++ b/packages/arex/src/services/ReportService/queryPlanStatistics.ts
@@ -68,7 +68,11 @@ export async function queryPlanStatistics(
     .post<QueryPlanStatisticsRes>('/report/report/queryPlanStatistics', requestParams)
     .then((res) =>
       Promise.resolve({
-        total: res.body.totalCount,
+        pagination: {
+          current,
+          pageSize,
+          total: res.body.totalCount,
+        },
         list: res.body.planStatisticList.sort((a, b) => b.replayStartTime - a.replayStartTime),
       }),
     );


### PR DESCRIPTION
定义: `状态重置`——请求数据，并触发点击第一行事件
问题: 当当前页存在`运行中`类型的报告时，有轮询逻辑并触发`状态重置`
期望: 在`初始化`和`切换页数`时期望发生`状态重置`，而`轮询`时不应当发生`状态重置`，
