### PR TITLE
refactor: arex case save

### DIFF
--- a/packages/arex-request/src/types/ArexRESTRequest.ts
+++ b/packages/arex-request/src/types/ArexRESTRequest.ts
@@ -4,7 +4,7 @@ import { ArexRESTParam } from './ArexRESTParam';
 import { ArexRESTReqBody } from './ArexRESTReqBody';
 
 export interface ArexRESTRequest {
-  v: string;
+  v?: string;
   id: string; // Firebase Firestore ID
   name: string;
   method: string;

--- a/packages/arex/src/components/CollectionSelect/index.tsx
+++ b/packages/arex/src/components/CollectionSelect/index.tsx
@@ -226,12 +226,13 @@ const CollectionSelect: FC<CollectionSelectProps> = (props) => {
 
   const handleAddNode: CollectionNodeTitleProps['onAddNode'] = (infoId, nodeType) => {
     handleSelect(infoId, {
-      // @ts-ignore
-      node: {
-        infoId,
-        nodeType,
-        method: RequestMethodEnum.GET,
-      },
+      infoId,
+      nodeType,
+      method: RequestMethodEnum.GET,
+      nodeName: nodeType === CollectionNodeType.interface ? 'New Request' : 'case',
+      caseSourceType: CollectionNodeType.case,
+      labelIds: null,
+      children: [],
     });
     setExpandedKeys([...(expandedKeys || []), infoId]);
   };

--- a/packages/arex/src/panes/Request/Request.tsx
+++ b/packages/arex/src/panes/Request/Request.tsx
@@ -429,6 +429,7 @@ const Request: ArexPaneFC<RequestProps> = (props) => {
         nodeType={nodeType}
         workspaceId={workspaceId}
         pathInfo={pathInfo}
+        data={data}
         // debug case save params
         appName={decodeURIComponent(props.data?.appName || '')}
         interfaceName={decodeURIComponent(props.data?.interfaceName || '')}

--- a/packages/arex/src/panes/Request/extra/tabs/response/Compare.tsx
+++ b/packages/arex/src/panes/Request/extra/tabs/response/Compare.tsx
@@ -145,12 +145,12 @@ const Compare: FC<CompareProps> = (props) => {
                   ref={jsonDiffViewRef}
                   height={`calc(100% - 4px)`}
                   diffJson={{
-                    left: diffMsg?.baseMsg || '',
-                    right: diffMsg?.testMsg || '',
+                    left: diffMsg?.testMsg || '',
+                    right: diffMsg?.baseMsg || '',
                   }}
                   remarks={{
-                    left: t('common:realtime'),
-                    right: t('common:record'),
+                    left: t('common:record'),
+                    right: t('common:realtime'),
                   }}
                   onClassName={(path, value, target) =>
                     logEntity?.pathPair[`${target}UnmatchedPath`]

--- a/packages/arex/src/services/FileSystemService/collection/addItemsByAppNameAndInterfaceName.ts
+++ b/packages/arex/src/services/FileSystemService/collection/addItemsByAppNameAndInterfaceName.ts
@@ -1,6 +1,7 @@
+import { BaseInterface } from '@/services/FileSystemService';
 import request from '@/utils/request';
 
-export interface AddItemsByAppNameAndInterfaceNameReq {
+export interface AddItemsByAppNameAndInterfaceNameReq extends Partial<BaseInterface> {
   recordId: string;
   workspaceId: string;
   operationId: string;

--- a/packages/arex/src/services/FileSystemService/request/saveRequest.ts
+++ b/packages/arex/src/services/FileSystemService/request/saveRequest.ts
@@ -3,12 +3,10 @@ import type { ArexRESTRequest } from '@arextest/arex-request';
 import { CollectionNodeType } from '@/constant';
 import { request } from '@/utils';
 
-export async function saveRequest(
-  workspaceId: string,
-  params: ArexRESTRequest & { inherited?: boolean; tags: string[] },
-  nodeType: number,
+export function convertRequestParams(
+  params: ArexRESTRequest & { workspaceId: string; inherited?: boolean; tags: string[] },
 ) {
-  const saveParams = {
+  return {
     address:
       params.method || params.endpoint
         ? {
@@ -38,12 +36,20 @@ export async function saveRequest(
       },
     ],
     // id
-    workspaceId: workspaceId,
+    workspaceId: params.workspaceId,
     id: params.id,
     inherited: params.inherited,
     description: params.description,
     labelIds: params.tags,
   };
+}
+
+export async function saveRequest(
+  workspaceId: string,
+  params: ArexRESTRequest & { inherited?: boolean; tags: string[] },
+  nodeType: number,
+) {
+  const saveParams = convertRequestParams({ ...params, workspaceId });
   const res = await request.post<{ success: boolean }>(
     `/webApi/filesystem/${
       nodeType === CollectionNodeType.interface ? 'saveInterface' : 'saveCase'


### PR DESCRIPTION
Feat: 
For default saving of debug cases, synchronize the case information to the interface.

Detail:
Enhance the `/addItemsByAppNameAndInterfaceName` interface in the save process to replace the original process of requesting four interfaces (`/addItem`,`/queryWorkspaceById`,`/saveCase`,`/pinMock`)